### PR TITLE
Add methods for paginating deleted documents

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,17 @@
 {
-  "name": "mongoose-paginate",
+  "name": "@metrica-sports/mongoose-paginate",
   "description": "Pagination plugin for Mongoose",
-  "version": "5.0.3",
+  "version": "1.0.0",
   "author": {
+    "name": "Metrica Sports",
+    "email": "info@metrica-sports.com"
+  },
+  "versionForked": "5.0.3",
+  "authorForked": {
     "name": "Edward Hotchkiss",
     "email": "edward@edwardhotchkiss.com"
   },
-  "contributors": [
+  "contributorsForked": [
     {
       "name": "Edward Hotchkiss",
       "email": "edward@edwardhotchkiss.com"
@@ -22,7 +27,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/edwardhotchkiss/mongoose-paginate.git"
+    "url": "https://github.com/metrica-sports/mongoose-paginate"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
   },
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Add `paginateDeleted` and `paginateWithDeleted` methods in order to paginate documents with `mongoose-delete` package. Mongoose methods `find` and `count` must be overridden with `mongoose-delete` in those models where these new functions wants to be used.